### PR TITLE
Generic syscall handling

### DIFF
--- a/pinchy-common/src/lib.rs
+++ b/pinchy-common/src/lib.rs
@@ -30,6 +30,7 @@ pub union SyscallEventData {
     pub futex: FutexData,
     pub sched_yield: SchedYieldData,
     pub ioctl: IoctlData,
+    pub generic: GenericSyscallData,
 }
 
 #[repr(C)]
@@ -103,4 +104,10 @@ pub struct IoctlData {
     pub fd: i32,
     pub request: u32,
     pub arg: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GenericSyscallData {
+    pub args: [usize; 6],
 }

--- a/pinchy-common/src/syscalls/mod.rs
+++ b/pinchy-common/src/syscalls/mod.rs
@@ -14,18 +14,6 @@ pub use x86_64::*;
 #[cfg(not(any(aarch64, x86_64)))]
 compile_error!("Unsupported architecture. Currently only aarch64 and x86_64 are supported.");
 
-pub const ALL_SUPPORTED_SYSCALLS: &[i64] = &[
-    SYS_close,
-    SYS_futex,
-    SYS_read,
-    SYS_epoll_pwait,
-    SYS_ppoll,
-    SYS_lseek,
-    SYS_openat,
-    SYS_sched_yield,
-    SYS_ioctl,
-];
-
 #[macro_export]
 macro_rules! declare_syscalls {
     (
@@ -38,5 +26,12 @@ macro_rules! declare_syscalls {
                 _ => None,
             }
         }
+        pub fn syscall_name_from_nr(nr: i64) -> Option<&'static str> {
+            match nr {
+                $( $name => Some(&stringify!($name)[4..]), )*
+                _ => None,
+            }
+        }
+        pub const ALL_SYSCALLS: &[i64] = &[$($name),*];
     };
 }

--- a/pinchy-ebpf/src/main.rs
+++ b/pinchy-ebpf/src/main.rs
@@ -431,6 +431,28 @@ pub fn syscall_exit_ioctl(ctx: TracePointContext) -> u32 {
     }
 }
 
+#[tracepoint]
+pub fn syscall_exit_generic(ctx: TracePointContext) -> u32 {
+    fn inner(ctx: TracePointContext) -> Result<(), u32> {
+        let syscall_nr = get_syscall_nr(&ctx)?;
+        let args = get_args(&ctx, syscall_nr)?;
+        let return_value = get_return_value(&ctx)?;
+
+        output_event(
+            &ctx,
+            syscall_nr,
+            return_value,
+            pinchy_common::SyscallEventData {
+                generic: pinchy_common::GenericSyscallData { args },
+            },
+        )
+    }
+    match inner(ctx) {
+        Ok(_) => 0,
+        Err(ret) => ret,
+    }
+}
+
 #[inline(always)]
 fn read_timespec(ptr: *const Timespec) -> Timespec {
     unsafe { bpf_probe_read_user::<Timespec>(ptr) }.unwrap_or_default()

--- a/pinchy/src/client.rs
+++ b/pinchy/src/client.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use clap::Parser;
-use pinchy_common::syscalls::{syscall_nr_from_name, ALL_SUPPORTED_SYSCALLS};
+use pinchy_common::syscalls::{syscall_nr_from_name, ALL_SYSCALLS};
 use zbus::{names::WellKnownName, proxy, Connection};
 
 #[proxy(interface = "org.pinchy.Service", default_path = "/org/pinchy/Service")]
@@ -19,7 +19,7 @@ fn parse_syscall_names(names: &[String]) -> Result<Vec<i64>, String> {
     let mut out = Vec::new();
     for name in names {
         match syscall_nr_from_name(name) {
-            Some(nr) if ALL_SUPPORTED_SYSCALLS.contains(&nr) => out.push(nr),
+            Some(nr) if ALL_SYSCALLS.contains(&nr) => out.push(nr),
             Some(_) => return Err(format!("Syscall '{name}' is not supported by this build")),
             None => return Err(format!("Unknown syscall name: {name}")),
         }
@@ -50,7 +50,7 @@ async fn main() -> zbus::Result<()> {
             }
         }
     } else {
-        ALL_SUPPORTED_SYSCALLS.to_vec()
+        ALL_SYSCALLS.to_vec()
     };
     let connection = Connection::system().await?;
     let destination = WellKnownName::try_from("org.pinchy.Service").unwrap();


### PR DESCRIPTION
Add generic handling for all known syscalls (assisted: claude)
    
This allows us to show something for all syscalls right away, while we
slowly go through the list adding specific parsing for each.