### PR TITLE
Add support for the execve syscall (assisted GPT 4.1)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,10 +65,7 @@ a dedicated handler.
 1. **Verify existence:** Confirm `SYS_<name>` exists in both arch files
    (see `pinchy-common/src/syscalls/aarch64.rs` and
    `pinchy-common/src/syscalls/x86_64.rs`).
-2. **ALL_SUPPORTED_SYSCALLS:** Add the syscall to the
-   `ALL_SUPPORTED_SYSCALLS` array in
-   `pinchy-common/src/syscalls/mod.rs`.
-3. **Trivial or complex:**
+2. **Trivial or complex:**
    - If trivial (no pointers, all arguments are plain integers):
      - Add to the match in `pinchy-ebpf/src/main.rs` in
        `try_syscall_exit_trivial`.
@@ -79,9 +76,9 @@ a dedicated handler.
        `pinchy-ebpf/src/main.rs`.
      - Register it in the appropriate array in `load_tailcalls()` in
        `pinchy/src/server.rs`.
-4. **Event parsing:** Add to the event parsing code in
+3. **Event parsing:** Add to the event parsing code in
    `pinchy/src/events.rs`.
-5. **Test:** Ensure the new syscall is being traced and parsed
+4. **Test:** Ensure the new syscall is being traced and parsed
    correctly.
 
 ## Building

--- a/pinchy-common/src/lib.rs
+++ b/pinchy-common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod kernel_types;
 pub mod syscalls;
 
 pub const DATA_READ_SIZE: usize = 128;
+pub const SMALL_READ_SIZE: usize = 8;
 
 #[repr(C)]
 pub struct SyscallEvent {
@@ -30,6 +31,7 @@ pub union SyscallEventData {
     pub futex: FutexData,
     pub sched_yield: SchedYieldData,
     pub ioctl: IoctlData,
+    pub execve: ExecveData,
     pub generic: GenericSyscallData,
 }
 
@@ -104,6 +106,19 @@ pub struct IoctlData {
     pub fd: i32,
     pub request: u32,
     pub arg: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ExecveData {
+    pub filename: [u8; SMALL_READ_SIZE * 4],
+    pub filename_truncated: bool,
+    pub argv: [[u8; SMALL_READ_SIZE]; 4],
+    pub argv_len: [u16; 4],
+    pub argc: u8,
+    pub envp: [[u8; SMALL_READ_SIZE]; 2],
+    pub envp_len: [u16; 2],
+    pub envc: u8,
 }
 
 #[repr(C)]


### PR DESCRIPTION
This is a tricky one, as the process memory goes away after it is done, so we need to add an enter handler specifically for execve, so that we can read the arguments and save them for the exit one.

AI was surprisingly useful, doing most of the work. It got a bit confused when dealing with the string and array truncation, but otherwise I am amazed by how much it was able to do.