### PR TITLE
Drop privileges after initial set up

### DIFF
--- a/pinchy/Cargo.toml
+++ b/pinchy/Cargo.toml
@@ -19,6 +19,7 @@ bytes = "1.10.1"
 zbus = { version = "5.7", features = ["tokio"] }
 zbus_macros = "5.7"
 clap = { workspace = true, default-features = true, features = ["derive"] }
+nix = "0.30.1"
 
 [build-dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
We need privileges to create eBPF maps, load eBPF programs, open perf events and obtain our well-known D-Bus name. After all of that is done we can drop to either the pinchy user - if it exists as a system uid - or nobody as a fallback.