### PR TITLE
Better idle tracking

### DIFF
--- a/pinchy/tests/integration.rs
+++ b/pinchy/tests/integration.rs
@@ -88,6 +88,7 @@ fn auto_quit_after_client() {
         //.env("RUST_LOG", "trace")
         .arg(cargo_bin("test-helper"))
         .arg("pinchy_reads")
+        .stdout(Stdio::null())
         .spawn()
         .unwrap();
 

--- a/pinchy/tests/integration.rs
+++ b/pinchy/tests/integration.rs
@@ -73,8 +73,8 @@ fn auto_quit() {
 
     let elapsed = now.elapsed().as_secs();
 
-    // Check if we exited in around 10 seconds.
-    assert!(elapsed.abs_diff(10) < 5);
+    // Check if we exited in around 15 seconds.
+    assert!(elapsed.abs_diff(15) < 5);
 }
 
 #[test]


### PR DESCRIPTION
 As things standed, if stars lined up just right you could have pinchyd
quit right after running a trace, as that trace would not refresh the
idle timer. Now we reset the timer when a new message is received.