### PR TITLE
New syscalls and iovec handling refactor

### DIFF
--- a/pinchy-common/src/kernel_types.rs
+++ b/pinchy-common/src/kernel_types.rs
@@ -343,14 +343,13 @@ pub struct Iovec {
 /// Message header structure for socket message operations
 /// Note: we only capture essential fields and a subset of the control message data
 /// due to eBPF stack limitations
-pub const MSG_IOV_COUNT: usize = 4; // Number of iovec structures to capture
 pub const MSG_CONTROL_SIZE: usize = 64; // Size of control message data to capture
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Msghdr {
     pub msg_name: u64,                        // Optional address pointer
     pub msg_namelen: u32,                     // Size of address
-    pub msg_iov: [Iovec; MSG_IOV_COUNT],      // Scatter/gather array (truncated)
+    pub msg_iov: [Iovec; crate::IOV_COUNT],   // Scatter/gather array (truncated)
     pub msg_iovlen: u32,                      // Number of elements in msg_iov
     pub msg_control: u64,                     // Ancillary data pointer
     pub msg_controllen: u32,                  // Ancillary data buffer size
@@ -375,7 +374,7 @@ impl Default for Msghdr {
         Self {
             msg_name: 0,
             msg_namelen: 0,
-            msg_iov: [Iovec::default(); MSG_IOV_COUNT],
+            msg_iov: [Iovec::default(); crate::IOV_COUNT],
             msg_iovlen: 0,
             msg_control: 0,
             msg_controllen: 0,

--- a/pinchy-ebpf/src/basic_io.rs
+++ b/pinchy-ebpf/src/basic_io.rs
@@ -170,7 +170,7 @@ syscall_handler!(readv, vector_io, args, data, return_value, {
         IovecOp::Read,
         &mut data.iovecs,
         &mut data.iov_lens,
-        &mut data.iov_bufs,
+        Some(&mut data.iov_bufs),
         &mut data.read_count,
         return_value,
     );
@@ -187,7 +187,7 @@ syscall_handler!(writev, vector_io, args, data, return_value, {
         IovecOp::Write,
         &mut data.iovecs,
         &mut data.iov_lens,
-        &mut data.iov_bufs,
+        Some(&mut data.iov_bufs),
         &mut data.read_count,
         return_value,
     );
@@ -205,7 +205,7 @@ syscall_handler!(preadv, vector_io, args, data, return_value, {
         IovecOp::Read,
         &mut data.iovecs,
         &mut data.iov_lens,
-        &mut data.iov_bufs,
+        Some(&mut data.iov_bufs),
         &mut data.read_count,
         return_value,
     );
@@ -223,7 +223,7 @@ syscall_handler!(pwritev, vector_io, args, data, return_value, {
         IovecOp::Write,
         &mut data.iovecs,
         &mut data.iov_lens,
-        &mut data.iov_bufs,
+        Some(&mut data.iov_bufs),
         &mut data.read_count,
         return_value,
     );
@@ -242,7 +242,7 @@ syscall_handler!(preadv2, vector_io, args, data, return_value, {
         IovecOp::Read,
         &mut data.iovecs,
         &mut data.iov_lens,
-        &mut data.iov_bufs,
+        Some(&mut data.iov_bufs),
         &mut data.read_count,
         return_value,
     );
@@ -261,7 +261,7 @@ syscall_handler!(pwritev2, vector_io, args, data, return_value, {
         IovecOp::Write,
         &mut data.iovecs,
         &mut data.iov_lens,
-        &mut data.iov_bufs,
+        Some(&mut data.iov_bufs),
         &mut data.read_count,
         return_value,
     );
@@ -413,7 +413,7 @@ syscall_handler!(vmsplice, vmsplice, args, data, return_value, {
         IovecOp::Write,
         &mut data.iovecs,
         &mut data.iov_lens,
-        &mut data.iov_bufs,
+        Some(&mut data.iov_bufs),
         &mut data.read_count,
         return_value,
     );

--- a/pinchy-ebpf/src/memory.rs
+++ b/pinchy-ebpf/src/memory.rs
@@ -1,12 +1,10 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // Copyright (c) 2025 Gustavo Noronha Silva <gustavo@noronha.dev.br>
 
-use core::mem::size_of;
-
-use aya_ebpf::helpers::bpf_probe_read_user;
-use pinchy_common::kernel_types::Iovec;
-
-use crate::syscall_handler;
+use crate::{
+    syscall_handler,
+    util::{read_iovec_array, IovecOp},
+};
 
 syscall_handler!(mmap, args, data, {
     data.addr = args[0];
@@ -28,34 +26,89 @@ syscall_handler!(madvise, args, data, {
     data.advice = args[2] as i32;
 });
 
-syscall_handler!(process_madvise, args, data, {
+syscall_handler!(process_madvise, process_madvise, args, data, {
     data.pidfd = args[0] as i32;
     data.iovcnt = args[2] as usize;
     data.advice = args[3] as i32;
     data.flags = args[4] as u32;
-    data.read_count = core::cmp::min(data.iovcnt, pinchy_common::IOV_COUNT);
 
     let iov_addr = args[1] as u64;
+    read_iovec_array(
+        iov_addr,
+        data.iovcnt,
+        IovecOp::AddressOnly, // Don't read buffer contents for madvise
+        &mut data.iovecs,
+        &mut data.iov_lens,
+        None, // No buffer needed for AddressOnly
+        &mut data.read_count,
+        0, // return_value not relevant for AddressOnly
+    );
+});
 
-    // Read only the iovec structures, not the buffer contents since these are addresses in another process
-    for i in 0..data.read_count {
-        let iov_ptr = (iov_addr as *const u8).wrapping_add(i * size_of::<Iovec>());
+syscall_handler!(process_vm_readv, process_vm, args, data, return_value, {
+    data.pid = args[0] as i32;
+    data.local_iovcnt = args[2] as usize;
+    data.remote_iovcnt = args[4] as usize;
+    data.flags = args[5] as u64;
 
-        let iov_base = unsafe {
-            bpf_probe_read_user::<*const u8>(iov_ptr as *const _).unwrap_or(core::ptr::null())
-        };
+    let local_addr = args[1] as u64;
+    let remote_addr = args[3] as u64;
 
-        if iov_base.is_null() {
-            continue;
-        }
+    // Read local iovec array (with buffer contents since it's readable by us)
+    read_iovec_array(
+        local_addr,
+        data.local_iovcnt,
+        IovecOp::Read,
+        &mut data.local_iovecs,
+        &mut data.local_iov_lens,
+        Some(&mut data.local_iov_bufs),
+        &mut data.local_read_count,
+        return_value,
+    );
 
-        let iov_len =
-            unsafe { bpf_probe_read_user::<u64>((iov_ptr as *const u64).add(1)).unwrap_or(0) };
+    // Read remote iovec array (address-only since we can't read remote process memory)
+    read_iovec_array(
+        remote_addr,
+        data.remote_iovcnt,
+        IovecOp::AddressOnly,
+        &mut data.remote_iovecs,
+        &mut data.remote_iov_lens,
+        None, // No buffer needed for AddressOnly
+        &mut data.remote_read_count,
+        return_value,
+    );
+});
 
-        data.iovecs[i] = Iovec {
-            iov_base: iov_base as u64,
-            iov_len,
-        };
-        data.iov_lens[i] = iov_len as usize;
-    }
+syscall_handler!(process_vm_writev, process_vm, args, data, return_value, {
+    data.pid = args[0] as i32;
+    data.local_iovcnt = args[2] as usize;
+    data.remote_iovcnt = args[4] as usize;
+    data.flags = args[5] as u64;
+
+    let local_addr = args[1] as u64;
+    let remote_addr = args[3] as u64;
+
+    // Read local iovec array (with buffer contents since it's readable by us)
+    read_iovec_array(
+        local_addr,
+        data.local_iovcnt,
+        IovecOp::Write,
+        &mut data.local_iovecs,
+        &mut data.local_iov_lens,
+        Some(&mut data.local_iov_bufs),
+        &mut data.local_read_count,
+        return_value,
+    );
+
+    // Read remote iovec array (address-only since we can't read remote process memory)
+    read_iovec_array(
+        remote_addr,
+        data.remote_iovcnt,
+        IovecOp::AddressOnly,
+        &mut data.remote_iovecs,
+        &mut data.remote_iov_lens,
+        None, // No buffer needed for AddressOnly
+        &mut data.remote_read_count,
+        return_value,
+    );
 });

--- a/pinchy/src/server.rs
+++ b/pinchy/src/server.rs
@@ -472,6 +472,14 @@ fn load_tailcalls(ebpf: &mut Ebpf) -> anyhow::Result<()> {
             "syscall_exit_process_madvise",
             syscalls::SYS_process_madvise,
         ),
+        (
+            "syscall_exit_process_vm_readv",
+            syscalls::SYS_process_vm_readv,
+        ),
+        (
+            "syscall_exit_process_vm_writev",
+            syscalls::SYS_process_vm_writev,
+        ),
         ("syscall_exit_statfs", syscalls::SYS_statfs),
         ("syscall_exit_fstatfs", syscalls::SYS_fstatfs),
         ("syscall_exit_fsopen", syscalls::SYS_fsopen),

--- a/pinchy/tests/integration.rs
+++ b/pinchy/tests/integration.rs
@@ -741,8 +741,8 @@ fn readv_writev_syscalls() {
 
     // Expected output - readv and writev calls
     let expected_output = escaped_regex(indoc! {r#"
-        PID writev(fd: NUMBER, iov: [ iovec { base: "Hello, ", len: 7 }, iovec { base: "world!", len: 6 } ], iovcnt: 2) = 13 (bytes)
-        PID readv(fd: NUMBER, iov: [ iovec { base: "Hello, ", len: 7 }, iovec { base: "world!", len: 6 } ], iovcnt: 2) = 13 (bytes)
+        PID writev(fd: NUMBER, iov: [ iovec { base: ADDR, len: 7, buf: "Hello, " }, iovec { base: ADDR, len: 6, buf: "world!" } ], iovcnt: 2) = 13 (bytes)
+        PID readv(fd: NUMBER, iov: [ iovec { base: ADDR, len: 7, buf: "Hello, " }, iovec { base: ADDR, len: 6, buf: "world!" } ], iovcnt: 2) = 13 (bytes)
     "#});
 
     let output = handle.join().unwrap();


### PR DESCRIPTION
This change adds support for process_vm_{readv, writev}, but also changes several other handlers to make iovec handling share more code and be more consistent.