### PR TITLE
Add support for Process category syscalls

### DIFF
--- a/pinchy-common/src/lib.rs
+++ b/pinchy-common/src/lib.rs
@@ -403,6 +403,11 @@ pub union SyscallEventData {
     pub seccomp: SeccompData,
     pub quotactl: QuotactlData,
     pub quotactl_fd: QuotactlFdData,
+    pub kcmp: KcmpData,
+    pub getgroups: GetgroupsData,
+    pub setgroups: SetgroupsData,
+    pub getresuid: GetresuidData,
+    pub getresgid: GetresgidData,
 }
 
 #[repr(C)]
@@ -3288,4 +3293,68 @@ pub struct QuotactlFdData {
     pub cmd: u32,
     pub id: i32,
     pub addr: u64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct KcmpData {
+    pub pid1: i32,
+    pub pid2: i32,
+    pub type_: i32,
+    pub idx1: u64,
+    pub idx2: u64,
+}
+
+pub const GROUP_ARRAY_CAP: usize = 16;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct GetgroupsData {
+    pub size: i32,
+    pub groups: [u32; GROUP_ARRAY_CAP],
+    pub groups_read_count: u32,
+}
+
+impl Default for GetgroupsData {
+    fn default() -> Self {
+        Self {
+            size: 0,
+            groups: [0; GROUP_ARRAY_CAP],
+            groups_read_count: 0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct SetgroupsData {
+    pub size: usize,
+    pub groups: [u32; GROUP_ARRAY_CAP],
+    pub groups_read_count: u32,
+}
+
+impl Default for SetgroupsData {
+    fn default() -> Self {
+        Self {
+            size: 0,
+            groups: [0; GROUP_ARRAY_CAP],
+            groups_read_count: 0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct GetresuidData {
+    pub ruid: u32,
+    pub euid: u32,
+    pub suid: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct GetresgidData {
+    pub rgid: u32,
+    pub egid: u32,
+    pub sgid: u32,
 }

--- a/pinchy/src/events.rs
+++ b/pinchy/src/events.rs
@@ -2334,6 +2334,101 @@ pub async fn handle_event(event: &SyscallEvent, formatter: Formatter<'_>) -> any
 
             finish!(sf, event.return_value);
         }
+        syscalls::SYS_kcmp => {
+            let data = unsafe { event.data.kcmp };
+
+            argf!(sf, "pid1: {}", data.pid1);
+            argf!(sf, "pid2: {}", data.pid2);
+            argf!(
+                sf,
+                "type: {}",
+                crate::format_helpers::format_kcmp_type(data.type_)
+            );
+            argf!(sf, "idx1: {}", data.idx1);
+            argf!(sf, "idx2: {}", data.idx2);
+
+            finish!(sf, event.return_value);
+        }
+        syscalls::SYS_getgroups => {
+            let data = unsafe { event.data.getgroups };
+
+            argf!(sf, "size: {}", data.size);
+
+            if data.groups_read_count > 0 {
+                let groups: Vec<String> = data.groups[..data.groups_read_count as usize]
+                    .iter()
+                    .map(|g| g.to_string())
+                    .collect();
+
+                if data.groups_read_count < event.return_value as u32
+                    && event.return_value > pinchy_common::GROUP_ARRAY_CAP as i64
+                {
+                    argf!(
+                        sf,
+                        "list: [{}... (showing {} of {})]",
+                        groups.join(", "),
+                        data.groups_read_count,
+                        event.return_value
+                    );
+                } else {
+                    argf!(sf, "list: [{}]", groups.join(", "));
+                }
+            } else if data.size == 0 {
+                arg!(sf, "list: NULL");
+            } else {
+                argf!(sf, "list: []");
+            }
+
+            finish!(sf, event.return_value);
+        }
+        syscalls::SYS_setgroups => {
+            let data = unsafe { event.data.setgroups };
+
+            argf!(sf, "size: {}", data.size);
+
+            if data.groups_read_count > 0 {
+                let groups: Vec<String> = data.groups[..data.groups_read_count as usize]
+                    .iter()
+                    .map(|g| g.to_string())
+                    .collect();
+
+                if data.groups_read_count < data.size as u32
+                    && data.size > pinchy_common::GROUP_ARRAY_CAP
+                {
+                    argf!(
+                        sf,
+                        "list: [{}... (showing {} of {})]",
+                        groups.join(", "),
+                        data.groups_read_count,
+                        data.size
+                    );
+                } else {
+                    argf!(sf, "list: [{}]", groups.join(", "));
+                }
+            } else {
+                argf!(sf, "list: []");
+            }
+
+            finish!(sf, event.return_value);
+        }
+        syscalls::SYS_getresuid => {
+            let data = unsafe { event.data.getresuid };
+
+            argf!(sf, "ruid: {}", data.ruid);
+            argf!(sf, "euid: {}", data.euid);
+            argf!(sf, "suid: {}", data.suid);
+
+            finish!(sf, event.return_value);
+        }
+        syscalls::SYS_getresgid => {
+            let data = unsafe { event.data.getresgid };
+
+            argf!(sf, "rgid: {}", data.rgid);
+            argf!(sf, "egid: {}", data.egid);
+            argf!(sf, "sgid: {}", data.sgid);
+
+            finish!(sf, event.return_value);
+        }
         syscalls::SYS_rseq => {
             let data = unsafe { event.data.rseq };
 

--- a/pinchy/src/server.rs
+++ b/pinchy/src/server.rs
@@ -829,6 +829,11 @@ fn load_tailcalls(ebpf: &mut Ebpf) -> anyhow::Result<()> {
         syscalls::SYS_clone,
         syscalls::SYS_pidfd_send_signal,
         syscalls::SYS_prlimit64,
+        syscalls::SYS_kcmp,
+        syscalls::SYS_getgroups,
+        syscalls::SYS_setgroups,
+        syscalls::SYS_getresuid,
+        syscalls::SYS_getresgid,
     ];
     let process_prog: &mut aya::programs::TracePoint = ebpf
         .program_mut("syscall_exit_process")


### PR DESCRIPTION
This adds support for 5 Process-related syscalls:
- kcmp: compare kernel resources between processes
- getgroups/setgroups: manage supplementary group IDs
- getresuid/getresgid: get real, effective, and saved UIDs/GIDs

Added format_kcmp_type() helper with 8 KCMP type constants. Specialized return value formatting:
- kcmp: shows comparison result (equal, less than, greater than, not equal)
- getgroups: shows count of groups returned
- setgroups, getresuid, getresgid: show success/error

Added 5 pretty printing tests in pinchy/src/tests/process.rs. All 535 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)