### PR TITLE
Add support for legacy memory management syscalls

### DIFF
--- a/pinchy-common/src/lib.rs
+++ b/pinchy-common/src/lib.rs
@@ -408,6 +408,10 @@ pub union SyscallEventData {
     pub setgroups: SetgroupsData,
     pub getresuid: GetresuidData,
     pub getresgid: GetresgidData,
+    pub memfd_create: MemfdCreateData,
+    pub pkey_mprotect: PkeyMprotectData,
+    pub mseal: MsealData,
+    pub remap_file_pages: RemapFilePagesData,
 }
 
 #[repr(C)]
@@ -3357,4 +3361,47 @@ pub struct GetresgidData {
     pub rgid: u32,
     pub egid: u32,
     pub sgid: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct MemfdCreateData {
+    pub name: [u8; SMALL_READ_SIZE],
+    pub flags: u32,
+}
+
+impl Default for MemfdCreateData {
+    fn default() -> Self {
+        Self {
+            name: [0; SMALL_READ_SIZE],
+            flags: 0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct PkeyMprotectData {
+    pub addr: u64,
+    pub len: u64,
+    pub prot: i32,
+    pub pkey: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct MsealData {
+    pub addr: u64,
+    pub len: u64,
+    pub flags: u64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct RemapFilePagesData {
+    pub addr: u64,
+    pub size: u64,
+    pub prot: i32,
+    pub pgoff: u64,
+    pub flags: i32,
 }

--- a/pinchy/src/events.rs
+++ b/pinchy/src/events.rs
@@ -2021,6 +2021,46 @@ pub async fn handle_event(event: &SyscallEvent, formatter: Formatter<'_>) -> any
 
             finish!(sf, event.return_value);
         }
+        syscalls::SYS_memfd_create => {
+            let data = unsafe { event.data.memfd_create };
+
+            let name = format_path(&data.name, false);
+
+            argf!(sf, "name: {}", name);
+            argf!(sf, "flags: {}", format_memfd_create_flags(data.flags));
+
+            finish!(sf, event.return_value);
+        }
+        syscalls::SYS_pkey_mprotect => {
+            let data = unsafe { event.data.pkey_mprotect };
+
+            argf!(sf, "addr: 0x{:x}", data.addr);
+            argf!(sf, "len: {}", data.len);
+            argf!(sf, "prot: {}", format_mmap_prot(data.prot));
+            argf!(sf, "pkey: {}", data.pkey);
+
+            finish!(sf, event.return_value);
+        }
+        syscalls::SYS_mseal => {
+            let data = unsafe { event.data.mseal };
+
+            argf!(sf, "addr: 0x{:x}", data.addr);
+            argf!(sf, "len: {}", data.len);
+            argf!(sf, "flags: {}", format_mseal_flags(data.flags));
+
+            finish!(sf, event.return_value);
+        }
+        syscalls::SYS_remap_file_pages => {
+            let data = unsafe { event.data.remap_file_pages };
+
+            argf!(sf, "addr: 0x{:x}", data.addr);
+            argf!(sf, "size: {}", data.size);
+            argf!(sf, "prot: {}", format_mmap_prot(data.prot));
+            argf!(sf, "pgoff: {}", data.pgoff);
+            argf!(sf, "flags: {}", format_mmap_flags(data.flags));
+
+            finish!(sf, event.return_value);
+        }
         syscalls::SYS_getrandom => {
             let data = unsafe { event.data.getrandom };
 

--- a/pinchy/src/server.rs
+++ b/pinchy/src/server.rs
@@ -671,6 +671,10 @@ fn load_tailcalls(ebpf: &mut Ebpf) -> anyhow::Result<()> {
         syscalls::SYS_migrate_pages,
         syscalls::SYS_move_pages,
         syscalls::SYS_mincore,
+        syscalls::SYS_memfd_create,
+        syscalls::SYS_pkey_mprotect,
+        syscalls::SYS_mseal,
+        syscalls::SYS_remap_file_pages,
     ];
     let memory_prog: &mut aya::programs::TracePoint = ebpf
         .program_mut("syscall_exit_memory")


### PR DESCRIPTION
Implements:
- memfd_create: create anonymous file in memory
- pkey_mprotect: set protection with memory protection key
- mseal: seal memory region (Linux 6.10+)
- remap_file_pages: remap file pages (deprecated)

- Add data structures for all 4 syscalls
- Add eBPF handlers in memory.rs
- Register syscalls in MEMORY_SYSCALLS
- Add format_memfd_create_flags() helper with MFD_* constants
- Add return value formatting (fd for memfd_create, success/error for others)
- Add 5 pretty printing tests
- All 540 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)