### PR TITLE
Add support for system management syscalls

### DIFF
--- a/pinchy-common/src/kernel_types.rs
+++ b/pinchy-common/src/kernel_types.rs
@@ -27,6 +27,9 @@ pub const IOCB_FLAG_IOPRIO: u32 = 1 << 1; // aio_reqprio is valid
 pub const AIO_IOCB_ARRAY_CAP: usize = 4;
 pub const AIO_EVENT_ARRAY_CAP: usize = 4;
 
+// Constants for kexec_load
+pub const KEXEC_SEGMENT_ARRAY_CAP: usize = 16;
+
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Pollfd {
@@ -885,4 +888,15 @@ pub struct SeccompNotifSizes {
     pub seccomp_notif: u16,      // Size of notification structure
     pub seccomp_notif_resp: u16, // Size of response structure
     pub seccomp_data: u16,       // Size of 'struct seccomp_data'
+}
+
+/// Kernel memory segment descriptor for kexec_load
+/// See: https://man7.org/linux/man-pages/man2/kexec_load.2.html
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct KexecSegment {
+    pub buf: u64,   // Buffer in user space (void* as u64)
+    pub bufsz: u64, // Buffer length in user space (size_t as u64)
+    pub mem: u64,   // Physical address of kernel (void* as u64)
+    pub memsz: u64, // Physical address length (size_t as u64)
 }

--- a/pinchy-common/src/lib.rs
+++ b/pinchy-common/src/lib.rs
@@ -412,6 +412,8 @@ pub union SyscallEventData {
     pub pkey_mprotect: PkeyMprotectData,
     pub mseal: MsealData,
     pub remap_file_pages: RemapFilePagesData,
+    pub restart_syscall: RestartSyscallData,
+    pub kexec_load: KexecLoadData,
 }
 
 #[repr(C)]
@@ -3404,4 +3406,21 @@ pub struct RemapFilePagesData {
     pub prot: i32,
     pub pgoff: u64,
     pub flags: i32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct RestartSyscallData {
+    // No arguments
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct KexecLoadData {
+    pub entry: u64,
+    pub nr_segments: u64,
+    pub segments: u64,
+    pub flags: u64,
+    pub segments_read: u64,
+    pub parsed_segments: [kernel_types::KexecSegment; kernel_types::KEXEC_SEGMENT_ARRAY_CAP],
 }

--- a/pinchy/src/server.rs
+++ b/pinchy/src/server.rs
@@ -719,6 +719,8 @@ fn load_tailcalls(ebpf: &mut Ebpf) -> anyhow::Result<()> {
         syscalls::SYS_perf_event_open,
         syscalls::SYS_bpf,
         syscalls::SYS_syslog,
+        syscalls::SYS_restart_syscall,
+        syscalls::SYS_kexec_load,
     ];
     let system_prog: &mut aya::programs::TracePoint = ebpf
         .program_mut("syscall_exit_system")


### PR DESCRIPTION
Implements restart_syscall and kexec_load from Batch 11 (Legacy & Misc).

restart_syscall:
- Kernel-internal syscall for resuming interrupted syscalls
- Takes no arguments
- Returns 0 on success

kexec_load:
- Load new kernel for execution (kexec mechanism)
- Arguments: entry point, nr_segments, segments pointer, flags
- Flags include KEXEC_ON_CRASH, KEXEC_PRESERVE_CONTEXT, and architecture constants (KEXEC_ARCH_X86_64, KEXEC_ARCH_AARCH64, etc.)
- Added kexec_constants module with all flag definitions from linux/include/uapi/linux/kexec.h
- Created format_kexec_load_flags() helper for pretty-printing flags
- Returns 0 on success

Added 4 pretty printing tests covering both syscalls and various flag combinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)