### PR TITLE
Add support for legacy filesystem syscalls

### DIFF
--- a/pinchy-common/src/kernel_types.rs
+++ b/pinchy-common/src/kernel_types.rs
@@ -45,6 +45,14 @@ pub struct Timespec {
     pub nanos: i64,
 }
 
+/// Structure for utime syscall
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Utimbuf {
+    pub actime: i64,  // Access time
+    pub modtime: i64, // Modification time
+}
+
 /// Structure for openat2 syscall, matching the kernel's struct open_how
 /// See: https://man7.org/linux/man-pages/man2/openat2.2.html
 #[repr(C)]

--- a/pinchy-common/src/lib.rs
+++ b/pinchy-common/src/lib.rs
@@ -414,6 +414,9 @@ pub union SyscallEventData {
     pub remap_file_pages: RemapFilePagesData,
     pub restart_syscall: RestartSyscallData,
     pub kexec_load: KexecLoadData,
+    pub lookup_dcookie: LookupDcookieData,
+    pub nfsservctl: NfsservctlData,
+    pub utime: UtimeData,
 }
 
 #[repr(C)]
@@ -3423,4 +3426,28 @@ pub struct KexecLoadData {
     pub flags: u64,
     pub segments_read: u64,
     pub parsed_segments: [kernel_types::KexecSegment; kernel_types::KEXEC_SEGMENT_ARRAY_CAP],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct LookupDcookieData {
+    pub cookie: u64,
+    pub buffer: [u8; MEDIUM_READ_SIZE],
+    pub size: u64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct NfsservctlData {
+    pub cmd: i32,
+    pub argp: u64,
+    pub resp: u64,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct UtimeData {
+    pub filename: [u8; DATA_READ_SIZE],
+    pub times: kernel_types::Utimbuf,
+    pub times_is_null: u8,
 }

--- a/pinchy/src/events.rs
+++ b/pinchy/src/events.rs
@@ -4661,6 +4661,48 @@ pub async fn handle_event(event: &SyscallEvent, formatter: Formatter<'_>) -> any
 
             finish!(sf, event.return_value);
         }
+        syscalls::SYS_lookup_dcookie => {
+            let data = unsafe { event.data.lookup_dcookie };
+
+            argf!(sf, "cookie: {}", data.cookie);
+
+            let buffer = format_path(&data.buffer, false);
+
+            argf!(sf, "buffer: {}", buffer);
+            argf!(sf, "size: {}", data.size);
+
+            finish!(sf, event.return_value);
+        }
+        syscalls::SYS_nfsservctl => {
+            let data = unsafe { event.data.nfsservctl };
+
+            argf!(sf, "cmd: {}", data.cmd);
+            argf!(sf, "argp: 0x{:x}", data.argp);
+            argf!(sf, "resp: 0x{:x}", data.resp);
+
+            finish!(sf, event.return_value);
+        }
+        #[cfg(target_arch = "x86_64")]
+        syscalls::SYS_utime => {
+            let data = unsafe { event.data.utime };
+
+            let filename = format_path(&data.filename, false);
+
+            argf!(sf, "filename: {}", filename);
+
+            if data.times_is_null != 0 {
+                argf!(sf, "times: NULL");
+            } else {
+                argf!(
+                    sf,
+                    "times: {{actime: {}, modtime: {}}}",
+                    data.times.actime,
+                    data.times.modtime
+                );
+            }
+
+            finish!(sf, event.return_value);
+        }
         _ => {
             let data = unsafe { event.data.generic };
 

--- a/pinchy/src/format_helpers.rs
+++ b/pinchy/src/format_helpers.rs
@@ -2327,7 +2327,8 @@ pub fn format_return_value(syscall_nr: i64, return_value: i64) -> std::borrow::C
         | syscalls::SYS_process_vm_readv
         | syscalls::SYS_process_vm_writev
         | syscalls::SYS_sched_getaffinity
-        | syscalls::SYS_copy_file_range => {
+        | syscalls::SYS_copy_file_range
+        | syscalls::SYS_lookup_dcookie => {
             if return_value >= 0 {
                 std::borrow::Cow::Owned(format!("{return_value} (bytes)"))
             } else {
@@ -2492,7 +2493,8 @@ pub fn format_return_value(syscall_nr: i64, return_value: i64) -> std::borrow::C
         | syscalls::SYS_getresuid
         | syscalls::SYS_getresgid
         | syscalls::SYS_restart_syscall
-        | syscalls::SYS_kexec_load => match return_value {
+        | syscalls::SYS_kexec_load
+        | syscalls::SYS_nfsservctl => match return_value {
             0 => std::borrow::Cow::Borrowed("0 (success)"),
             _ => std::borrow::Cow::Owned(format!("{return_value} (error)")),
         },
@@ -2532,7 +2534,8 @@ pub fn format_return_value(syscall_nr: i64, return_value: i64) -> std::borrow::C
         | syscalls::SYS_rename
         | syscalls::SYS_mknod
         | syscalls::SYS_stat
-        | syscalls::SYS_lstat => match return_value {
+        | syscalls::SYS_lstat
+        | syscalls::SYS_utime => match return_value {
             0 => std::borrow::Cow::Borrowed("0 (success)"),
             _ => std::borrow::Cow::Owned(format!("{return_value} (error)")),
         },

--- a/pinchy/src/server.rs
+++ b/pinchy/src/server.rs
@@ -592,6 +592,10 @@ fn load_tailcalls(ebpf: &mut Ebpf) -> anyhow::Result<()> {
         syscalls::SYS_utimensat,
         syscalls::SYS_quotactl,
         syscalls::SYS_quotactl_fd,
+        syscalls::SYS_lookup_dcookie,
+        syscalls::SYS_nfsservctl,
+        #[cfg(target_arch = "x86_64")]
+        syscalls::SYS_utime,
     ];
     let filesystem_prog: &mut aya::programs::TracePoint = ebpf
         .program_mut("syscall_exit_filesystem")


### PR DESCRIPTION
Implements lookup_dcookie, nfsservctl, and utime

lookup_dcookie:
- Converts directory entry cookie to path
- Arguments: cookie (u64), buffer pointer, buffer size
- Returns path length on success
- Used primarily by oprofile profiler
- Requires CAP_SYS_ADMIN capability

nfsservctl:
- Obsolete NFS daemon control syscall (removed in Linux 3.1)
- Arguments: cmd, argp pointer, resp pointer
- Returns 0 on success
- Replaced by nfsd filesystem interface

utime (x86_64 only):
- Change file access and modification times
- Arguments: pathname, times pointer (or NULL)
- times is a Utimbuf struct with actime and modtime fields
- NULL times sets both timestamps to current time
- Returns 0 on success

Added Utimbuf struct to kernel_types.rs for utime syscall. Added 5 pretty printing tests covering all three syscalls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)