### PR TITLE
Simplify x86_64 syscall implementation

### DIFF
--- a/pinchy-common/src/lib.rs
+++ b/pinchy-common/src/lib.rs
@@ -271,9 +271,9 @@ pub fn compact_payload_size(syscall_nr: i64) -> Option<usize> {
         #[cfg(x86_64)]
         syscalls::SYS_kexec_file_load => Some(core::mem::size_of::<KexecFileLoadData>()),
         #[cfg(x86_64)]
-        syscalls::SYS_get_thread_area => Some(core::mem::size_of::<GetThreadAreaData>()),
-        #[cfg(x86_64)]
-        syscalls::SYS_set_thread_area => Some(core::mem::size_of::<SetThreadAreaData>()),
+        syscalls::SYS_get_thread_area | syscalls::SYS_set_thread_area => {
+            Some(core::mem::size_of::<ThreadAreaData>())
+        }
         #[cfg(x86_64)]
         syscalls::SYS_modify_ldt => Some(core::mem::size_of::<ModifyLdtData>()),
         #[cfg(x86_64)]
@@ -3715,9 +3715,9 @@ pub struct FutimesatData {
 #[derive(Clone, Copy)]
 pub struct Fadvise64Data {
     pub fd: i32,
+    pub advice: i32,
     pub offset: i64,
     pub len: i64,
-    pub advice: i32,
 }
 
 #[repr(C)]
@@ -3759,13 +3759,7 @@ pub struct KexecFileLoadData {
 
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct GetThreadAreaData {
-    pub u_info: u64,
-}
-
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct SetThreadAreaData {
+pub struct ThreadAreaData {
     pub u_info: u64,
 }
 

--- a/pinchy-ebpf/src/main.rs
+++ b/pinchy-ebpf/src/main.rs
@@ -18,8 +18,8 @@ use pinchy_common::EFF_STAT_COUNT;
 use pinchy_common::{syscalls, FchmodData, FchownData, FdatasyncData, FsyncData, FtruncateData};
 #[cfg(x86_64)]
 use pinchy_common::{
-    ArchPrctlData, DeprecatedSyscallData, Fadvise64Data, GetThreadAreaData, IopermData, IoplData,
-    KexecFileLoadData, ModifyLdtData, SetThreadAreaData, TimeData,
+    ArchPrctlData, DeprecatedSyscallData, Fadvise64Data, IopermData, IoplData, KexecFileLoadData,
+    ModifyLdtData, ThreadAreaData, TimeData,
 };
 
 use crate::util::{get_args, get_syscall_nr, submit_compact_payload};
@@ -1195,9 +1195,9 @@ pub fn syscall_exit_trivial(ctx: TracePointContext) -> u32 {
                     return_value,
                     |payload| {
                         payload.fd = args[0] as i32;
+                        payload.advice = args[3] as i32;
                         payload.offset = args[1] as i64;
                         payload.len = args[2] as i64;
-                        payload.advice = args[3] as i32;
                     },
                 )?;
             }
@@ -1264,21 +1264,10 @@ pub fn syscall_exit_trivial(ctx: TracePointContext) -> u32 {
                 )?;
             }
             #[cfg(x86_64)]
-            syscalls::SYS_get_thread_area => {
-                crate::util::submit_compact_payload::<GetThreadAreaData, _>(
+            syscalls::SYS_get_thread_area | syscalls::SYS_set_thread_area => {
+                crate::util::submit_compact_payload::<ThreadAreaData, _>(
                     &ctx,
-                    syscalls::SYS_get_thread_area,
-                    return_value,
-                    |payload| {
-                        payload.u_info = args[0] as u64;
-                    },
-                )?;
-            }
-            #[cfg(x86_64)]
-            syscalls::SYS_set_thread_area => {
-                crate::util::submit_compact_payload::<SetThreadAreaData, _>(
-                    &ctx,
-                    syscalls::SYS_set_thread_area,
+                    syscall_nr,
                     return_value,
                     |payload| {
                         payload.u_info = args[0] as u64;

--- a/pinchy/src/events.rs
+++ b/pinchy/src/events.rs
@@ -5709,7 +5709,7 @@ pub async fn handle_event(
         #[cfg(target_arch = "x86_64")]
         syscalls::SYS_get_thread_area | syscalls::SYS_set_thread_area => {
             let data = unsafe {
-                std::ptr::read_unaligned(payload.as_ptr() as *const pinchy_common::GetThreadAreaData)
+                std::ptr::read_unaligned(payload.as_ptr() as *const pinchy_common::ThreadAreaData)
             };
 
             argf!(sf, "u_info: 0x{:x}", data.u_info);
@@ -5748,10 +5748,10 @@ pub async fn handle_event(
                 )
             };
 
-            for arg in &data.args {
-                if *arg != 0 {
-                    argf!(sf, "0x{:x}", arg);
-                }
+            let last_nonzero = data.args.iter().rposition(|a| *a != 0).map_or(0, |i| i + 1);
+
+            for arg in &data.args[..last_nonzero] {
+                argf!(sf, "0x{:x}", arg);
             }
             finish!(sf, header.return_value);
         }

--- a/pinchy/src/format_helpers.rs
+++ b/pinchy/src/format_helpers.rs
@@ -2544,10 +2544,13 @@ pub fn format_return_value(syscall_nr: i64, return_value: i64) -> std::borrow::C
         | syscalls::SYS_security
         | syscalls::SYS_epoll_ctl_old
         | syscalls::SYS_epoll_wait_old
-        | syscalls::SYS_vserver => match return_value {
-            0 => std::borrow::Cow::Borrowed("0 (success)"),
-            _ => std::borrow::Cow::Owned(format!("{return_value} (error)")),
-        },
+        | syscalls::SYS_vserver => {
+            if return_value >= 0 {
+                std::borrow::Cow::Owned(format!("{return_value} (success)"))
+            } else {
+                std::borrow::Cow::Owned(format!("{return_value} (error)"))
+            }
+        }
 
         syscalls::SYS_kcmp => match return_value {
             0 => std::borrow::Cow::Borrowed("0 (equal)"),

--- a/pinchy/src/format_helpers.rs
+++ b/pinchy/src/format_helpers.rs
@@ -2529,6 +2529,26 @@ pub fn format_return_value(syscall_nr: i64, return_value: i64) -> std::borrow::C
             }
         }
 
+        #[cfg(target_arch = "x86_64")]
+        syscalls::SYS_uselib
+        | syscalls::SYS_ustat
+        | syscalls::SYS_sysfs
+        | syscalls::SYS__sysctl
+        | syscalls::SYS_create_module
+        | syscalls::SYS_get_kernel_syms
+        | syscalls::SYS_query_module
+        | syscalls::SYS_getpmsg
+        | syscalls::SYS_putpmsg
+        | syscalls::SYS_afs_syscall
+        | syscalls::SYS_tuxcall
+        | syscalls::SYS_security
+        | syscalls::SYS_epoll_ctl_old
+        | syscalls::SYS_epoll_wait_old
+        | syscalls::SYS_vserver => match return_value {
+            0 => std::borrow::Cow::Borrowed("0 (success)"),
+            _ => std::borrow::Cow::Owned(format!("{return_value} (error)")),
+        },
+
         syscalls::SYS_kcmp => match return_value {
             0 => std::borrow::Cow::Borrowed("0 (equal)"),
             1 => std::borrow::Cow::Borrowed("1 (less than)"),

--- a/pinchy/src/tests/return_values.rs
+++ b/pinchy/src/tests/return_values.rs
@@ -216,3 +216,20 @@ fn test_clock_adjtime_return_values() {
         "-95 (error)"
     );
 }
+
+#[cfg(target_arch = "x86_64")]
+#[test]
+fn test_deprecated_syscall_return_values() {
+    assert_eq!(
+        format_return_value(syscalls::SYS_tuxcall, 0).as_ref(),
+        "0 (success)"
+    );
+    assert_eq!(
+        format_return_value(syscalls::SYS_tuxcall, -38).as_ref(),
+        "-38 (error)"
+    );
+    assert_eq!(
+        format_return_value(syscalls::SYS_sysfs, 2).as_ref(),
+        "2 (success)"
+    );
+}

--- a/pinchy/src/tests/system.rs
+++ b/pinchy/src/tests/system.rs
@@ -1640,6 +1640,21 @@ syscall_test!(
 
 #[cfg(target_arch = "x86_64")]
 syscall_test!(
+    parse_deprecated_syscall_with_zero_arg,
+    {
+        use pinchy_common::DeprecatedSyscallData;
+
+        let data = DeprecatedSyscallData {
+            args: [0x1234, 0, 0x5678, 0, 0, 0],
+        };
+
+        crate::tests::make_compact_test_data(pinchy_common::syscalls::SYS_ustat, 100, -38, &data)
+    },
+    "100 ustat(0x1234, 0x0, 0x5678) = -38 (error)\n"
+);
+
+#[cfg(target_arch = "x86_64")]
+syscall_test!(
     parse_time,
     {
         use pinchy_common::TimeData;


### PR DESCRIPTION
## Summary

- Unify duplicate `GetThreadAreaData`/`SetThreadAreaData` into a single `ThreadAreaData`
- Reorder `Fadvise64Data` fields to eliminate 8 bytes of padding (matches `FallocateData` convention)
- Fix deprecated syscall arg printing to preserve positional order instead of silently skipping zeroes
- Add explicit `format_return_value` arm for all 15 deprecated syscalls

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` clean (no new warnings)
- [x] `cargo check` passes (including eBPF cross-compilation)
- [x] All 566 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)