### PR TITLE
Fix argument capture, error return, and parsing correctness issues

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,8 +52,8 @@ Supported architectures are `aarch64` and `x86_64`.
 
 - For eBPF user-memory reads:
   - use `bpf_probe_read_user()` for small structs,
-  - use `bpf_probe_read_buf()` for byte arrays/larger structs to avoid stack
-    pressure by reading directly into compact payload ringbuf memory.
+  - use `bpf_probe_read_user_buf()` for byte arrays/larger structs to avoid
+    stack pressure by reading directly into compact payload ringbuf memory.
 
 - Never use magic values in format helpers or tests. Prefer `libc::` constants;
   declare named constants when `libc` does not provide one.
@@ -73,7 +73,8 @@ Supported architectures are `aarch64` and `x86_64`.
 
 ## Adding a Syscall Checklist
 
-1. Confirm `SYS_<name>` exists in both arch syscall files.
+1. Confirm which arch syscall files define `SYS_<name>`; if only one,
+   cfg-gate all handling for that arch.
 2. Read the man page to understand pointer args and whether dereference is
    required:
    `https://man7.org/linux/man-pages/man2/SYSCALL_NAME.2.html`

--- a/pinchy-common/src/lib.rs
+++ b/pinchy-common/src/lib.rs
@@ -2557,7 +2557,6 @@ pub struct SigaltstackData {
 #[derive(Clone, Copy, Default)]
 pub struct SignalfdData {
     pub fd: i32,
-    pub flags: i32,
     pub mask: crate::kernel_types::Sigset,
     pub has_mask: bool,
 }

--- a/pinchy-ebpf/src/basic_io.rs
+++ b/pinchy-ebpf/src/basic_io.rs
@@ -219,7 +219,7 @@ pub fn syscall_exit_basic_io(ctx: TracePointContext) -> u32 {
                         if syscall_nr == syscalls::SYS_preadv2
                             || syscall_nr == syscalls::SYS_pwritev2
                         {
-                            payload.flags = args[4] as u32;
+                            payload.flags = args[5] as u32;
                         }
 
                         let iov_addr = args[1] as u64;
@@ -382,20 +382,16 @@ pub fn syscall_exit_basic_io(ctx: TracePointContext) -> u32 {
                         payload.nfds = args[1] as u32;
                         payload.timeout = args[2] as i32;
 
-                        let mut fds_ptr = args[0] as *const Pollfd;
+                        let fds_ptr = args[0] as *const Pollfd;
                         let fds = &mut payload.fds;
 
                         if !fds_ptr.is_null() && payload.nfds > 0 {
                             let max_fds = core::cmp::min(payload.nfds, 16) as usize;
                             for i in 0..max_fds {
-                                fds_ptr = unsafe { fds_ptr.add(i) };
-
-                                if fds_ptr.is_null() {
-                                    break;
-                                }
+                                let entry_ptr = unsafe { fds_ptr.add(i) };
 
                                 if let Ok(pollfd) =
-                                    unsafe { bpf_probe_read_user::<Pollfd>(fds_ptr) }
+                                    unsafe { bpf_probe_read_user::<Pollfd>(entry_ptr) }
                                 {
                                     fds[i] = pollfd;
                                     payload.actual_nfds += 1;

--- a/pinchy-ebpf/src/ipc.rs
+++ b/pinchy-ebpf/src/ipc.rs
@@ -219,14 +219,14 @@ pub fn syscall_exit_ipc(ctx: TracePointContext) -> u32 {
 
                         let arg_ptr = args[3] as *const kernel_types::Semun;
                         payload.has_arg = !arg_ptr.is_null();
-                        if payload.has_arg {
-                            match payload.op {
-                                SETVAL => {
-                                    let val_ptr = arg_ptr as *const i32;
 
-                                    payload.arg.val =
-                                        unsafe { bpf_probe_read_user::<i32>(val_ptr).unwrap_or(0) };
-                                }
+                        if payload.op == SETVAL {
+                            // For SETVAL the union is passed by value: the
+                            // argument is the value itself, not a pointer.
+                            payload.arg.val = args[3] as i32;
+                            payload.has_arg = true;
+                        } else if payload.has_arg {
+                            match payload.op {
                                 SETALL | GETALL => {
                                     let array_ptr = arg_ptr as *const u16;
 

--- a/pinchy-ebpf/src/signal.rs
+++ b/pinchy-ebpf/src/signal.rs
@@ -141,7 +141,6 @@ pub fn syscall_exit_signal(ctx: TracePointContext) -> u32 {
                     return_value,
                     |payload| {
                         payload.fd = args[0] as i32;
-                        payload.flags = args[2] as i32;
 
                         let mask_ptr = args[1] as *const kernel_types::Sigset;
                         if !mask_ptr.is_null() {
@@ -162,7 +161,7 @@ pub fn syscall_exit_signal(ctx: TracePointContext) -> u32 {
                     return_value,
                     |payload| {
                         payload.fd = args[0] as i32;
-                        payload.flags = args[2] as i32;
+                        payload.flags = args[3] as i32;
 
                         let mask_ptr = args[1] as *const kernel_types::Sigset;
                         if !mask_ptr.is_null() {

--- a/pinchy/src/client.rs
+++ b/pinchy/src/client.rs
@@ -7,7 +7,7 @@ use std::{ffi::OsString, io::IsTerminal, os::fd::OwnedFd, pin::Pin};
 use anyhow::Result;
 use clap::{CommandFactory as _, Parser};
 use pinchy_common::{
-    max_compact_payload_size,
+    compact_payload_size, max_compact_payload_size,
     syscalls::{syscall_nr_from_name, ALL_SYSCALLS},
     WireEventHeader, WIRE_VERSION,
 };
@@ -163,6 +163,21 @@ async fn relay_trace(fd: OwnedFd, formatting_style: FormattingStyle) -> Result<(
 
                 payload.resize(payload_len, 0);
                 reader.read_exact(&mut payload).await?;
+
+                // handle_event() reads the payload as a fixed-size struct;
+                // a short payload would be an out-of-bounds read.
+                if let Some(expected) = compact_payload_size(header.syscall_nr) {
+                    if payload_len != expected {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!(
+                                "payload_len {} does not match expected {} for syscall {}",
+                                payload_len, expected, header.syscall_nr
+                            ),
+                        )
+                        .into());
+                    }
+                }
 
                 output.clear();
 

--- a/pinchy/src/events.rs
+++ b/pinchy/src/events.rs
@@ -1816,8 +1816,6 @@ pub async fn handle_event(
                 arg!(sf, "mask: NULL");
             }
 
-            argf!(sf, "flags: {}", format_signalfd_flags(data.flags));
-
             finish!(sf, header.return_value);
         }
         syscalls::SYS_signalfd4 => {

--- a/pinchy/src/events.rs
+++ b/pinchy/src/events.rs
@@ -348,16 +348,18 @@ pub async fn handle_event(
             format_timespec(&mut sf, data.timeout).await?;
             arg!(sf, "sigmask");
 
-            let extra_info = match header.return_value {
-                0 => None,
-                -1 => None,
-                _ => Some(format!(
+            // revents are only meaningful when some fds became ready; a
+            // timeout (0) or an error (raw -errno) has none to report.
+            let extra_info = if header.return_value > 0 {
+                Some(format!(
                     " [{}]",
                     data.fds.iter().zip(data.revents.iter()).join_take_map(
                         data.nfds as usize,
                         |(fd, event)| format!("{fd} = {}", format_poll_events(*event))
                     )
-                )),
+                ))
+            } else {
+                None
             };
 
             match extra_info {

--- a/pinchy/src/events.rs
+++ b/pinchy/src/events.rs
@@ -5756,14 +5756,16 @@ pub async fn handle_event(
             finish!(sf, header.return_value);
         }
         _ => {
-            let data = unsafe {
-                std::ptr::read_unaligned(
-                    payload.as_ptr() as *const pinchy_common::GenericSyscallData
-                )
-            };
+            if payload.len() >= size_of::<pinchy_common::GenericSyscallData>() {
+                let data = unsafe {
+                    std::ptr::read_unaligned(
+                        payload.as_ptr() as *const pinchy_common::GenericSyscallData
+                    )
+                };
 
-            for i in 0..data.args.len() {
-                argf!(sf, "{}", data.args[i]);
+                for i in 0..data.args.len() {
+                    argf!(sf, "{}", data.args[i]);
+                }
             }
 
             finish!(sf, header.return_value, b" <STUB>");

--- a/pinchy/src/format_helpers.rs
+++ b/pinchy/src/format_helpers.rs
@@ -2615,7 +2615,7 @@ pub fn format_return_value(syscall_nr: i64, return_value: i64) -> std::borrow::C
             // The events.rs handler will override this with the extra parameter
             match return_value {
                 0 => std::borrow::Cow::Borrowed("0 (timeout)"),
-                -1 => std::borrow::Cow::Borrowed("-1 (error)"),
+                n if n < 0 => std::borrow::Cow::Owned(format!("{return_value} (error)")),
                 _ => std::borrow::Cow::Owned(format!("{return_value} (ready)")),
             }
         }
@@ -2665,19 +2665,26 @@ pub fn format_return_value(syscall_nr: i64, return_value: i64) -> std::borrow::C
             }
         }
 
-        // Memory address returning syscalls
+        // Memory address returning syscalls; errors are -errno in the
+        // -4095..0 range, anything else is a valid address
         syscalls::SYS_mmap | syscalls::SYS_mremap => {
-            if return_value == -1 {
-                std::borrow::Cow::Borrowed("-1 (error)")
+            if (-4095..0).contains(&return_value) {
+                std::borrow::Cow::Owned(format!("{return_value} (error)"))
             } else {
                 std::borrow::Cow::Owned(format!("0x{return_value:x} (addr)"))
             }
         }
 
-        // Syscalls that return an address
-        syscalls::SYS_brk | syscalls::SYS_shmat => {
-            std::borrow::Cow::Owned(format!("0x{return_value:x}"))
+        syscalls::SYS_shmat => {
+            if (-4095..0).contains(&return_value) {
+                std::borrow::Cow::Owned(format!("{return_value} (error)"))
+            } else {
+                std::borrow::Cow::Owned(format!("0x{return_value:x}"))
+            }
         }
+
+        // brk returns the new (or unchanged) break, never an error
+        syscalls::SYS_brk => std::borrow::Cow::Owned(format!("0x{return_value:x}")),
 
         // Page migration syscalls return page counts
         syscalls::SYS_migrate_pages => {
@@ -2758,22 +2765,22 @@ pub fn format_return_value(syscall_nr: i64, return_value: i64) -> std::borrow::C
         },
 
         syscalls::SYS_shmget => match return_value {
-            -1 => std::borrow::Cow::Owned(format!("{return_value} (error)")),
+            n if n < 0 => std::borrow::Cow::Owned(format!("{return_value} (error)")),
             _ => std::borrow::Cow::Owned(format!("{return_value} (shmid)")),
         },
 
         syscalls::SYS_msgget => match return_value {
-            -1 => std::borrow::Cow::Owned(format!("{return_value} (error)")),
+            n if n < 0 => std::borrow::Cow::Owned(format!("{return_value} (error)")),
             _ => std::borrow::Cow::Owned(format!("{return_value} (msqid)")),
         },
 
         syscalls::SYS_semget => match return_value {
-            -1 => std::borrow::Cow::Owned(format!("{return_value} (error)")),
+            n if n < 0 => std::borrow::Cow::Owned(format!("{return_value} (error)")),
             _ => std::borrow::Cow::Owned(format!("{return_value} (semid)")),
         },
 
         syscalls::SYS_inotify_add_watch => match return_value {
-            -1 => std::borrow::Cow::Owned(format!("{return_value} (error)")),
+            n if n < 0 => std::borrow::Cow::Owned(format!("{return_value} (error)")),
             _ => std::borrow::Cow::Owned(format!("{return_value} (wd)")),
         },
 
@@ -2795,19 +2802,19 @@ pub fn format_return_value(syscall_nr: i64, return_value: i64) -> std::borrow::C
 
         // Special syscalls with unique return value semantics
         syscalls::SYS_membarrier => match return_value {
-            -1 => std::borrow::Cow::Borrowed("-1 (error)"),
+            n if n < 0 => std::borrow::Cow::Owned(format!("{return_value} (error)")),
             0 => std::borrow::Cow::Borrowed("0 (success)"),
             _ => std::borrow::Cow::Owned(format!("{return_value} (bitmask)")),
         },
 
         syscalls::SYS_pkey_alloc => match return_value {
-            -1 => std::borrow::Cow::Borrowed("-1 (error)"),
+            n if n < 0 => std::borrow::Cow::Owned(format!("{return_value} (error)")),
             _ => std::borrow::Cow::Owned(format!("{return_value} (pkey)")),
         },
 
         // Signal-related syscalls with special return semantics
         syscalls::SYS_rt_sigtimedwait => match return_value {
-            -1 => std::borrow::Cow::Borrowed("-1 (error)"),
+            n if n < 0 => std::borrow::Cow::Owned(format!("{return_value} (error)")),
             _ => std::borrow::Cow::Owned(format!("{return_value} (signal)")),
         },
 

--- a/pinchy/src/server.rs
+++ b/pinchy/src/server.rs
@@ -418,7 +418,6 @@ fn load_tailcalls(ebpf: &mut Ebpf) -> anyhow::Result<()> {
         syscalls::SYS_fchmod,
         syscalls::SYS_fchown,
         syscalls::SYS_flock,
-        syscalls::SYS_truncate,
         #[cfg(target_arch = "x86_64")]
         syscalls::SYS_epoll_create,
         syscalls::SYS_epoll_create1,

--- a/pinchy/src/tests/return_values.rs
+++ b/pinchy/src/tests/return_values.rs
@@ -233,3 +233,59 @@ fn test_deprecated_syscall_return_values() {
         "2 (success)"
     );
 }
+
+#[test]
+fn test_raw_errno_return_values() {
+    // Raw sys_exit values are -errno, not just -1; any negative value is an
+    // error for these syscalls
+    assert_eq!(
+        format_return_value(syscalls::SYS_ppoll, -(libc::EINTR as i64)).as_ref(),
+        "-4 (error)"
+    );
+    assert_eq!(
+        format_return_value(syscalls::SYS_mmap, -(libc::ENOMEM as i64)).as_ref(),
+        "-12 (error)"
+    );
+    assert_eq!(
+        format_return_value(syscalls::SYS_mremap, -(libc::EFAULT as i64)).as_ref(),
+        "-14 (error)"
+    );
+    assert_eq!(
+        format_return_value(syscalls::SYS_shmat, -(libc::EACCES as i64)).as_ref(),
+        "-13 (error)"
+    );
+    assert_eq!(
+        format_return_value(syscalls::SYS_shmget, -(libc::ENOENT as i64)).as_ref(),
+        "-2 (error)"
+    );
+    assert_eq!(
+        format_return_value(syscalls::SYS_msgget, -(libc::ENOENT as i64)).as_ref(),
+        "-2 (error)"
+    );
+    assert_eq!(
+        format_return_value(syscalls::SYS_semget, -(libc::ENOENT as i64)).as_ref(),
+        "-2 (error)"
+    );
+    assert_eq!(
+        format_return_value(syscalls::SYS_inotify_add_watch, -(libc::ENOSPC as i64)).as_ref(),
+        "-28 (error)"
+    );
+    assert_eq!(
+        format_return_value(syscalls::SYS_membarrier, -(libc::EINVAL as i64)).as_ref(),
+        "-22 (error)"
+    );
+    assert_eq!(
+        format_return_value(syscalls::SYS_pkey_alloc, -(libc::ENOSPC as i64)).as_ref(),
+        "-28 (error)"
+    );
+    assert_eq!(
+        format_return_value(syscalls::SYS_rt_sigtimedwait, -(libc::EAGAIN as i64)).as_ref(),
+        "-11 (error)"
+    );
+
+    // brk returns the new break, never an errno
+    assert_eq!(
+        format_return_value(syscalls::SYS_brk, 0x5500000000).as_ref(),
+        "0x5500000000"
+    );
+}

--- a/pinchy/src/tests/signal.rs
+++ b/pinchy/src/tests/signal.rs
@@ -450,7 +450,6 @@ syscall_test!(
 syscall_test!(
     parse_signalfd,
     {
-
         let mut mask = Sigset::default();
         let mut libc_mask: libc::sigset_t = unsafe { std::mem::zeroed() };
 
@@ -466,15 +465,14 @@ syscall_test!(
         });
 
         let data = pinchy_common::SignalfdData {
-                    fd: 5,
-                    flags: libc::SFD_CLOEXEC | libc::SFD_NONBLOCK,
-                    has_mask: true,
-                    mask,
-                };
+            fd: 5,
+            has_mask: true,
+            mask,
+        };
 
         crate::tests::make_compact_test_data(syscalls::SYS_signalfd, 102, 5, &data)
     },
-    "102 signalfd(fd: 5, mask: [SIGUSR1|SIGTERM], flags: 0x80800 (SFD_CLOEXEC|SFD_NONBLOCK)) = 5 (fd)\n"
+    "102 signalfd(fd: 5, mask: [SIGUSR1|SIGTERM]) = 5 (fd)\n"
 );
 
 syscall_test!(

--- a/pinchy/tests/integration.rs
+++ b/pinchy/tests/integration.rs
@@ -1413,7 +1413,7 @@ fn sysv_ipc_syscalls() {
         @PID@ msgrcv(msqid: @NUMBER@, msgp: @ADDR@, msgsz: 32, msgtyp: 0, msgflg: 0x0) = 30
         @PID@ msgctl(msqid: @NUMBER@, cmd: IPC_RMID, buf: NULL) = 0 (success)
         @PID@ semget(key: 0x11223344, nsems: 2, semflg: IPC_CREAT) = @NUMBER@ (semid)
-        @PID@ semctl(semid: @NUMBER@, semnum: 0, op: SETVAL, val: 0) = 0 (success)
+        @PID@ semctl(semid: @NUMBER@, semnum: 0, op: SETVAL, val: 5) = 0 (success)
         @PID@ semctl(semid: @NUMBER@, semnum: 0, op: GETVAL) = 5
         @PID@ semctl(semid: @NUMBER@, semnum: 0, op: IPC_RMID, arg: 0x0 (unknown)) = 0 (success)
     "#});


### PR DESCRIPTION
This is the first in a series of PRs from a full review pass over the code base (security, efficiency, latency, correctness, CLI affordances). It collects the outright bugs:

- **eBPF argument capture fixes**: the `poll` handler walked the pollfd array with a wrong pointer stride; `preadv2`/`pwritev2` read their flags from the wrong argument slot; `signalfd4` read flags from the wrong slot (and `signalfd` has no flags argument at all — the field was removed); `semctl` SETVAL dereferenced the by-value argument as if it were a pointer. The sysv_ipc integration test had the semctl bug baked into its expectations (asserted `val: 0` for a workload that sets 5) and was fixed accordingly.
- **Raw `-errno` returns**: `format_return_value` treated raw negative returns from the sys_exit tracepoint as success values for several syscalls; they are now consistently recognized as errors.
- **Duplicate tailcall registration**: `SYS_truncate` was registered in two tailcall arrays.
- **Client payload bounds check**: the client now validates `payload_len` against the expected compact payload size before `read_unaligned`, so a malformed or truncated stream cannot cause an out-of-bounds read.

Also carries a small agent-guidance accuracy fix (helper names, checklist wording, test marker table).

Note for review: the poll and signalfd fixes are in x86_64-cfg'd code paths that cannot be compile-checked on the aarch64 development machine — CI is the verification for those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)