### PR TITLE
Update UML test kernel to the arm64-uml-7.0 branch

### DIFF
--- a/uml-kernel/build-kernel.sh
+++ b/uml-kernel/build-kernel.sh
@@ -5,7 +5,7 @@
 # for use in rootless, parallel integration testing.
 #
 # The kernel source is from the ARM64 UML port at:
-#   https://github.com/kov/linux/tree/arm64-uml
+#   https://github.com/kov/linux/tree/arm64-uml-7.0
 #
 # Usage: ./build-kernel.sh [arch]
 #   arch: x86_64 or aarch64 (default: auto-detect from uname -m)
@@ -14,8 +14,8 @@ set -euo pipefail
 
 # Configuration
 KERNEL_GIT_URL="https://github.com/kov/linux.git"
-KERNEL_GIT_BRANCH="arm64-uml"
-KERNEL_GIT_COMMIT="f391975cd33f19c3da5cc58c217818af41ee3ec9"
+KERNEL_GIT_BRANCH="arm64-uml-7.0"
+KERNEL_GIT_COMMIT="383d0856e77baa21d8c814dd39319ca42b401fb4"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 CACHE_DIR="${SCRIPT_DIR}/cache"


### PR DESCRIPTION
Switch the pinned UML kernel source to the new 7.0-based ARM64 UML branch (`arm64-uml-7.0`, commit `383d0856e77b`).

The CI kernel cache key hashes `build-kernel.sh`, so the cached x86_64 kernel is rebuilt automatically.

Verified locally on aarch64: kernel 7.0.11 builds, all required config options survive `olddefconfig` (FANOTIFY, KEYS, SECURITY/SECURITYFS/LANDLOCK, NUMA, BPF), and all 72 integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)